### PR TITLE
Explicit Copy & Clone derive for CellTag

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -29,6 +29,7 @@ pub const CELL_TAG_BITS: u64 = 0x0007000000000000;
 /// Tag `0` is intentionally left undefined,
 /// to prevent the value ever accidentally
 /// becoming the original/sentinel `NaN`.
+#[derive(Copy, Clone)]
 #[repr(u64)]
 pub enum CellTag {
     // Tag0 is intentionally undefined.


### PR DESCRIPTION
It seems that depending on Rust compiler version, `#[repr(u64)]` does not automatically imply `Copy + Clone`.
This fixes that.