### PR TITLE
Fix unwrap tag

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -150,7 +150,7 @@ pub fn unwrap_tag_bits(value: impl IntoRawBits64) -> Option<u64> {
 #[inline(always)]
 pub fn unwrap_tag(value: impl IntoRawBits64) -> Option<CellTag> {
     match is_cell(value) {
-        true => CellTag::try_from(value.as_raw_bits_64()).ok(),
+        true => CellTag::try_from(value.as_raw_bits_64() & CELL_TAG_BITS).ok(),
         false => None
     }
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -29,6 +29,7 @@ pub const CELL_TAG_BITS: u64 = 0x0007000000000000;
 /// Tag `0` is intentionally left undefined,
 /// to prevent the value ever accidentally
 /// becoming the original/sentinel `NaN`.
+#[derive(Copy, Clone)]
 #[repr(u64)]
 pub enum CellTag {
     // Tag0 is intentionally undefined.

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -206,10 +206,13 @@ pub fn unwrap_cell_rawptr(value: impl IntoRawBits64) -> Option<*const ()> {
 /// However, performing any kind of logic- or arithmetic-operations
 /// on the returned value, will result in undefined behaviour.
 pub fn from_tag_and_pointer(tag: CellTag, ptr: *const ()) -> Option<u64> {
-    //let ptr: *const () = ptr.into();
+    from_tag_and_data(tag, ptr as u64)
+}
+
+pub fn from_tag_and_data(tag: CellTag, data: u64) -> Option<u64> {
     let vtag = (tag as u64) & CELL_TAG_BITS;
-    let vptr = (ptr as u64) & CELL_DATA_BITS;
+    let vdata = data & CELL_DATA_BITS;
     if vtag != tag as u64 {return None}
-    if vptr != ptr as u64 {return None}
-    Some(CELL_MARKER_BITS | vtag | vptr)
+    if vdata != data {return None}
+    Some(CELL_MARKER_BITS | vtag | vdata)
 }


### PR DESCRIPTION
This fixes a bug where the cell tag bits weren't properly masked when unwrapping into a `CellTag`.

Builds on #1 and #2.